### PR TITLE
Fix author url in source.json

### DIFF
--- a/source.json
+++ b/source.json
@@ -4,7 +4,7 @@
     "url":"https://vpm.vrsl.dev/index.json",
     "author":{
         "name":"AcChosen",
-        "url":"https://github.com/AcChosen/VR-Stage-Lighting"
+        "url":"https://github.com/AcChosen"
     },
     "description":"A collection of HLSL shaders, UdonSharp scripts, 3D models, prefabs, and assets designed to emulate the real control, quality, and complexity of professional stage lighting into VRChat in as many ways as possible.",
     "infoLink":{


### PR DESCRIPTION
Ideally should point to the author and not the individual repo, when creating a link using the author name for the website.
The direct repo link is included in the individual package.json entries instead.